### PR TITLE
Minor fix to mgcycle variable mutation in simpleCart

### DIFF
--- a/bin/cgns_utils.py
+++ b/bin/cgns_utils.py
@@ -2486,6 +2486,8 @@ def simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile):
 
     if isinstance(mgcycle, int):
         mgcycle = [mgcycle]*3
+    else:
+        assert(len(mgcycle) == 3)
 
     # Now determine how many nodes we need on the inside
     N = numpy.zeros(3, 'intc')

--- a/bin/cgns_utils.py
+++ b/bin/cgns_utils.py
@@ -2485,7 +2485,7 @@ def simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile):
         sym = [sym]
 
     if isinstance(mgcycle, int):
-        mgcycle = [mgcycle]
+        mgcycle = [mgcycle]*3
 
     # Now determine how many nodes we need on the inside
     N = numpy.zeros(3, 'intc')


### PR DESCRIPTION
Running the overset mesh tutorial command: `python generate_overset.py ...` pointed out this error, which I'm guessing is a typo.