### PR TITLE
Updated packages

### DIFF
--- a/bin/cgns_utils.py
+++ b/bin/cgns_utils.py
@@ -18,7 +18,7 @@ import shutil
 import tempfile
 import argparse
 import numpy
-from . import libcgns_utils
+import libcgns_utils
 import time
 
 # These are taken from the CGNS include file (cgnslib_f.h in your cgns library folder)

--- a/config.mk.info
+++ b/config.mk.info
@@ -4,16 +4,11 @@
 # so it is included in ${PETSC_LIB}. Otherwise you will have to
 # specify the HDF5 library.
 
-# ----------- CGNS 3.2.x ------------------
-CGNS_VERSION_FLAG=
+# ----------- CGNS ------------------
+# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
+CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
-
-# # ----------- CGNS 3.3.x ------------------
-# CGNS_VERSION_FLAG=-DUSECGNSMODULE
-# include ${PETSC_DIR}/lib/petsc/conf/variables
-# CGNS_INCLUDE_FLAGS=-I$(HOME)/packages/CGNS/src
-# CGNS_LINKER_FLAGS=-L$(HOME)/packages/CGNS/src/lib -lcgns ${PETSC_LIB}
 
 
 # Intel Fortran Compiler


### PR DESCRIPTION
## Purpose
Dependencies have bee updated to use
- CGNS 3.3
- PETSc 3.11.0
- openMPI 3.1.4

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
