### PR TITLE
Minor syntax changes

### DIFF
--- a/bin/cgns_utils
+++ b/bin/cgns_utils
@@ -11,7 +11,6 @@ read cngs file -> Do some operations on it -> |     .or.
 Developed by Dr. Gaetan K. W. Kenway
 
 """
-from __future__ import print_function, division
 import sys
 import os
 import copy
@@ -797,7 +796,7 @@ elif args.mode == 'cartesian':
     if found_overset:
         curGrid.cartesian(args.cartFile,args.outFile)
     else:
-        print ('The CGNS file has no overset boundary conditions')
+        print('The CGNS file has no overset boundary conditions')
     sys.exit(0)
 
 elif args.mode == 'simpleCart':
@@ -848,7 +847,7 @@ elif args.mode == 'include':
 
 elif args.mode == 'section':
     if len(curGrid.blocks) != 1:
-        print ('section command works only on grids with 1 block')
+        print('section command works only on grids with 1 block')
         sys.exit(0)
     curGrid.blocks[0].section(args.iStart, args.iEnd, args.jStart, args.jEnd,
                               args.kStart, args.kEnd)

--- a/bin/cgns_utils.py
+++ b/bin/cgns_utils.py
@@ -66,9 +66,9 @@ class Grid(object):
             totalCells += (blk.dims[0]-1)*(blk.dims[1]-1)*(blk.dims[2]-1)
             totalNodes += blk.dims[0]*blk.dims[1]*blk.dims[2]
 
-        print ('Total Zones:', len(self.blocks))
-        print ('Total Cells:', totalCells)
-        print ('Total Nodes:', totalNodes)
+        print('Total Zones:', len(self.blocks))
+        print('Total Cells:', totalCells)
+        print('Total Nodes:', totalNodes)
 
         boundaryNodes = 0
         boundaryCells = 0
@@ -100,8 +100,8 @@ class Grid(object):
                                          (ptRange[1, 1] - ptRange[1, 0] +1)
 
 
-        print ('Wall Boundary Cells:', boundaryCells)
-        print ('Wall Boundary Nodes:', boundaryNodes)
+        print('Wall Boundary Cells:', boundaryCells)
+        print('Wall Boundary Nodes:', boundaryNodes)
 
 
     def printBlockInfo(self):
@@ -114,16 +114,16 @@ class Grid(object):
         for blk in self.blocks:
             nCells = (blk.dims[0]-1)*(blk.dims[1]-1)*(blk.dims[2]-1)
             nNodes = blk.dims[0]*blk.dims[1]*blk.dims[2]
-            print ('Block Number:', counter)
-            print ('Number of Cells:', nCells)
-            print ('Number of Nodes:', nNodes)
+            print('Block Number:', counter)
+            print('Number of Cells:', nCells)
+            print('Number of Nodes:', nNodes)
             print('Block dimensions:', blk.dims)
             totalCells += nCells
             totalNodes += nNodes
             counter +=1
-        print ('Total Zones:', len(self.blocks))
-        print ('Total Cells:', totalCells)
-        print ('Total Nodes:', totalNodes)
+        print('Total Zones:', len(self.blocks))
+        print('Total Cells:', totalCells)
+        print('Total Nodes:', totalNodes)
 
     def addBlock(self, blk):
 
@@ -235,7 +235,7 @@ class Grid(object):
                 f.write('\n')
             f.close()
         else:
-            print ('Warning: No wall surfaces found!')
+            print('Warning: No wall surfaces found!')
 
     def extractSpecifiedSurface(self, fileName,blkid,imin,imax,jmin,jmax,kmin,kmax):
         """ Extract Specified surfaces and write to plot3d file"""
@@ -258,7 +258,7 @@ class Grid(object):
                 f.write('\n')
             f.close()
         else:
-            print ('Warning: No surfaces found!')
+            print('Warning: No surfaces found!')
 
     def overwriteFamilies(self, familyFile):
         """Overwrite families of BC with information given in the
@@ -621,7 +621,7 @@ class Grid(object):
         inLayer = 2 # How many layers of the overset interpolation
                     # faces will be used for volume computation
 
-        print ('Running cartesian grid generator')
+        print('Running cartesian grid generator')
 
         # Preallocate arrays
         extensions = numpy.zeros((2,3),order='F')
@@ -951,14 +951,14 @@ class Grid(object):
             gz = None
 
         # Print growth ratios
-        print ('')
-        print ('Maximum growth ratios along each direction:')
-        print ('X: ',gx)
-        print ('Y: ',gy)
-        print ('Z: ',gz)
+        print('')
+        print('Maximum growth ratios along each direction:')
+        print('X: ',gx)
+        print('Y: ',gy)
+        print('Z: ',gz)
         if max(gx,gy,gz) > 1.2:
-            print ("You may bring weightGR closer to 1 to decrease ratios")
-        print ('')
+            print("You may bring weightGR closer to 1 to decrease ratios")
+        print('')
 
         # Allocate coordinates block
         X = numpy.zeros((nNodes[0],nNodes[1],nNodes[2],3))
@@ -982,7 +982,7 @@ class Grid(object):
         libcgns_utils.utils.closefile(cg)
 
         # Print
-        print ('Mesh successfully generated and stored in: '+outFile)
+        print('Mesh successfully generated and stored in: '+outFile)
 
     def split(self, extraSplits):
 
@@ -2561,8 +2561,8 @@ def simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile):
     shp = [Xcart[0].shape[0], Xcart[1].shape[0], Xcart[2].shape[0]]
     X = numpy.zeros((shp[0], shp[1], shp[2], 3))
 
-    print ('Grid Dimensions:', shp)
-    print ('Grid Ratios:', r)
+    print('Grid Dimensions:', shp)
+    print('Grid Ratios:', r)
     # Write grid coordinates
     Xx, Xy, Xz = numpy.meshgrid(Xcart[0], Xcart[1], Xcart[2], indexing='ij')
     X[:,:,:,0] = Xx
@@ -2858,7 +2858,7 @@ def mergeGrid(grid):
                         blockUsed[otherIndex] == 0 and
                         i != otherIndex):
 
-                        print ('Merging:', i+1, otherIndex+1)
+                        print('Merging:', i+1, otherIndex+1)
 
                         # Great! These block match. Let's make the new
                         # block
@@ -3040,7 +3040,7 @@ def mergeGrid(grid):
 
         # Set the new blocks
         grid.blocks = newBlocks
-        print ("New number of blocks:", len(grid.blocks))
+        print("New number of blocks:", len(grid.blocks))
 
         # Rename the blocks and remove any B2B info since it will all
         # be recomputed:

--- a/bin/cgns_utils.py
+++ b/bin/cgns_utils.py
@@ -117,7 +117,7 @@ class Grid(object):
             print('Block Number:', counter)
             print('Number of Cells:', nCells)
             print('Number of Nodes:', nNodes)
-            print('Block dimensions:', blk.dims)
+            print('Block dimensions:', list(blk.dims))
             totalCells += nCells
             totalNodes += nNodes
             counter +=1

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ default:
 	 @echo "#------------------------------------------------------#"
 
 # Generate Numpy include directory
-	$(eval NUMPY_INCLUDES = $(shell $(PYTHON) -c 'from __future__ import print_function; import numpy; print(numpy.get_include())'))
+	$(eval NUMPY_INCLUDES = $(shell $(PYTHON) -c 'import numpy; print(numpy.get_include())'))
 	@echo "#------------------------------------------------------#"
 	@echo Numpy Include Directory: $(NUMPY_INCLUDES)
 	@echo "#------------------------------------------------------#"

--- a/src/get_f2py.py
+++ b/src/get_f2py.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #------------- VERY IMPORTANT ------------ 
 
 # This script is necessary since f2py INSISTS on priting crap out when
@@ -12,4 +11,4 @@ tmp = sys.stdout
 sys.stdout = sys.stderr
 import numpy.f2py
 sys.stdout = tmp
-print (os.path.dirname(os.path.abspath(numpy.f2py.__file__)))
+print(os.path.dirname(os.path.abspath(numpy.f2py.__file__)))

--- a/src/importTest.py
+++ b/src/importTest.py
@@ -2,12 +2,12 @@
 import sys
 
 name = 'libcgns_utils'
-print ("Testing if module %s can be imported..." % name)
+print("Testing if module %s can be imported..." % name)
 import_cmd = "import %s" % name
 try:
     exec(import_cmd)
 except:
-    print ("Error: libcgns_utils was not imported correctly")
+    print("Error: libcgns_utils was not imported correctly")
     sys.exit(1)
 # end try
 


### PR DESCRIPTION
This PR does two things:
- cosmetic changes to print, and removed future imports
- changed the `printBlockInfo` to cast `blk.dims` to list first. This makes the output easier to read from
`('Block dimensions:', array([257,   2, 129], dtype=int32))`
to
`('Block dimensions:', [257, 2, 129])`