### PR TITLE
Updated imports to use explicit import

### DIFF
--- a/bin/cgns_utils
+++ b/bin/cgns_utils
@@ -18,7 +18,6 @@ import shutil
 import tempfile
 import argparse
 import numpy
-import libcgns_utils
 import time
 os.sys.path.append(os.path.dirname(os.path.abspath('.')))
 from cgns_utils import *

--- a/bin/cgns_utils.py
+++ b/bin/cgns_utils.py
@@ -17,7 +17,7 @@ import shutil
 import tempfile
 import argparse
 import numpy
-import libcgns_utils
+from cgnsutilities.bin import libcgns_utils
 import time
 
 # These are taken from the CGNS include file (cgnslib_f.h in your cgns library folder)


### PR DESCRIPTION
## Purpose
The previous attempt (#8) at fixing the imports did not work. The issue is that this code is run both as a package, and as a standalone script. As such, imports had to be different (`from . import libcgns` when using as a package, and just `import libcgns` when called as a script). This is a [well-documented issue](https://stackoverflow.com/questions/16981921/relative-imports-in-python-3) with Python 3. I fixed this by switching to an explicit import statement (`from cgnsutilities.bin import libcgns`), which works as expected. Note that if you have multiple installations on your PYTHONPATH, then it's possible for the script to import from a different build, but the onus is on the user to ensure that only one package is available at a time. This is a fundamental limitation with how we install packages, i.e. in-place and modifying the PYTHONPATH.

I also removed a duplicated `libcgns` import in the script, since the `from cgns_utils import *` will import `libcgns` also.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Code works fine in py2 and py3, both invoking from the shell (`cgns_utils -h`) and importing as a package (`python -c "import cgnsutilities"`).

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes