### PR TITLE
updated pyHyp options

### DIFF
--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -556,13 +556,13 @@ class Grid(object):
         hypOptions = {
             "patches": patches,
             "unattachedEdgesAreSymmetry": True,
-            "outerFaceBC": "farField",
+            "outerFaceBC": "farfield",
             "autoConnect": True,
             "BC": {},
             "N": nExtra,
             "s0": numpy.average(dx),
             "marchDist": hExtra,
-            "cmax": 3,
+            "cmax": 3.0,
         }
 
         # Run pyHyp


### PR DESCRIPTION
## Purpose
Changes to the pyHyp options handling [here](https://github.com/mdolab/pyhyp/pull/36) will break the script in simpleOCart. I updated the options so that it will work with the new pyHyp update. These options will also work with older versions of pyHyp, and the mesh generation functionality is unchanged.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
I ran the mesh generation script in the overset tutorial to check that this works.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
