### PR TITLE
Fix NumPy Deprecation Warning (#26)

### DIFF
--- a/.github/azure-pipelines.yaml
+++ b/.github/azure-pipelines.yaml
@@ -15,6 +15,5 @@ extends:
   template: azure/azure_template.yaml@azure_template
   parameters:
     REPO_NAME: cgnsutilities
-    IGNORE_STYLE: true
     GCC_CONFIG: config/defaults/config.LINUX_GFORTRAN.mk
     INTEL_CONFIG: config/defaults/config.LINUX_INTEL.mk

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -217,11 +217,11 @@ class Grid(object):
 
                 f.write("%d %d 1\n" % (patches[i].shape[0], patches[i].shape[1]))
             for i in range(len(patches)):
-                patches[i][:, :, 0].flatten('F').tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 0].flatten("F").tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 1].flatten('F').tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 1].flatten("F").tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 2].flatten('F').tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 2].flatten("F").tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
             f.close()
         else:
@@ -239,11 +239,11 @@ class Grid(object):
 
                 f.write("%d %d 1\n" % (patches[i].shape[0], patches[i].shape[1]))
             for i in range(len(patches)):
-                patches[i][:, :, 0].flatten('F').tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 0].flatten("F").tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 1].flatten('F').tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 1].flatten("F").tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 2].flatten('F').tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 2].flatten("F").tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
             f.close()
         else:
@@ -1527,7 +1527,7 @@ class Block(object):
     def writeCoordsPlot3d(self, f):
         """Write coordinates to plot3d file"""
         for iDim in range(3):
-            self.coords[:, :, :, iDim].flatten('F').tofile(f, sep="\n", format="%20.15g")
+            self.coords[:, :, :, iDim].flatten("F").tofile(f, sep="\n", format="%20.15g")
             f.write("\n")
 
     def scale(self, scaleFact):

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -217,11 +217,11 @@ class Grid(object):
 
                 f.write("%d %d 1\n" % (patches[i].shape[0], patches[i].shape[1]))
             for i in range(len(patches)):
-                patches[i][:, :, 0].flatten(1).tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 0].flatten('F').tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 1].flatten(1).tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 1].flatten('F').tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 2].flatten(1).tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 2].flatten('F').tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
             f.close()
         else:
@@ -239,11 +239,11 @@ class Grid(object):
 
                 f.write("%d %d 1\n" % (patches[i].shape[0], patches[i].shape[1]))
             for i in range(len(patches)):
-                patches[i][:, :, 0].flatten(1).tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 0].flatten('F').tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 1].flatten(1).tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 1].flatten('F').tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
-                patches[i][:, :, 2].flatten(1).tofile(f, sep="\n", format="%20.15g")
+                patches[i][:, :, 2].flatten('F').tofile(f, sep="\n", format="%20.15g")
                 f.write("\n")
             f.close()
         else:
@@ -1527,7 +1527,7 @@ class Block(object):
     def writeCoordsPlot3d(self, f):
         """Write coordinates to plot3d file"""
         for iDim in range(3):
-            self.coords[:, :, :, iDim].flatten(1).tofile(f, sep="\n", format="%20.15g")
+            self.coords[:, :, :, iDim].flatten('F').tofile(f, sep="\n", format="%20.15g")
             f.write("\n")
 
     def scale(self, scaleFact):


### PR DESCRIPTION
Otherwise there will be errors like this

`ValueError: Non-string object detected for the array ordering. Please pass in 'C', 'F', 'A', or 'K' instead`

