### PR TITLE
Clean up help string

### DIFF
--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -4,9 +4,9 @@ This is the new gateway program to all of the cgns_utils.
 Run cgns_utils -help to get a list of all available options. The basic
 idea is as follows::
 
-                                                | write new file
+                                                  | write new file
     read cngs file -> Do some operations on it -> |     .or.
-                                                | write modified file
+                                                  | write modified file
 
 Developed by Dr. Gaetan K. W. Kenway
 
@@ -114,7 +114,7 @@ def get_parser():
     # ------------- Options for 'split' mode --------------------
     p_split = subparsers.add_parser(
         "split",
-        help="Face-match a grid. If the grid is already faced matched, this witll have no effect",
+        help="Face-match a grid. If the grid is already faced matched, this will have no effect",
     )
     p_split.add_argument("gridFile", help="Name of input CGNS file")
     p_split.add_argument("outFile", nargs="?", default=None, help="Optional output file")

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -2,11 +2,12 @@
 This is the new gateway program to all of the cgns_utils.
 
 Run cgns_utils -help to get a list of all available options. The basic
-idea is as follows:
+idea is as follows::
 
-                                              | write new file
-read cngs file -> Do some operations on it -> |     .or.
-                                              | write modified file
+                                                | write new file
+    read cngs file -> Do some operations on it -> |     .or.
+                                                | write modified file
+
 Developed by Dr. Gaetan K. W. Kenway
 
 """
@@ -368,7 +369,8 @@ def get_parser():
     # ------------ Options for 'remove' mode  --------------------
     p_rm = subparsers.add_parser(
         "remove",
-        help="Remove blocks from a cgns file. The user should ensure that the final mesh is still valid in terms of boundary conditions and connectivities.",
+        help="""Remove blocks from a cgns file. The user should ensure that the final mesh
+                is still valid in terms of boundary conditions and connectivities.""",
     )
     p_rm.add_argument("gridFile", help="Name of input CGNS file")
     p_rm.add_argument(
@@ -376,8 +378,7 @@ def get_parser():
         metavar="files",
         type=int,
         nargs="+",
-        help="IDs (integers) of the blocks that will be removed.\n\
-    The integers should be 1-indexed",
+        help="IDs (integers) of the blocks that will be removed. The integers should be 1-indexed",
     )
     p_rm.add_argument("outFile", type=str, help="Output CGNS file name")
 
@@ -390,18 +391,16 @@ def get_parser():
         "outFile",
         nargs="?",
         default=None,
-        help="Optional reference to name output files. \n\
-    An integer will be added to the end. \n\
-    if none is given, the input filename will be used as reference. \n\
-    All connectivity information between different blocks is lost in this step. Only \n\
-    internal connectivity remains.",
+        help="""Optional reference to name output files. An integer will be added to the end.
+                If none is given, the input filename will be used as reference.
+                All connectivity information between different blocks is lost in this step, only
+                internal connectivity remains.""",
     )
 
     # ------------ Options for 'explodeKmin' mode  --------------------
     p_expkmin = subparsers.add_parser(
         "explodeKmin",
-        help="Take one multiblock cgns file and explodes it into single-block plot3d files that contains \n\
-        only the K=1 faces.",
+        help="Take one multiblock cgns file and explodes it into single-block plot3d files that contains only the K=1 faces.",
     )
     p_expkmin.add_argument("gridFile", type=str, help="Name of input multiblock CGNS file")
     p_expkmin.add_argument(

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -166,7 +166,7 @@ def get_parser():
     p_bc.add_argument("outFile", nargs="?", default=None, help="Optional output file")
     p_bc.add_argument("--xOffset", nargs="?", default=0.0, type=float, help="x-coordinate of sphere origin")
     p_bc.add_argument("--yOffset", nargs="?", default=0.0, type=float, help="y-coordinate of sphere origin")
-    p_bc.add_argument("--zOffset", nargs="?", default=0.0, type=float, help="z--coordinate of sphere origin")
+    p_bc.add_argument("--zOffset", nargs="?", default=0.0, type=float, help="z-coordinate of sphere origin")
 
     # ------------ Options for 'family' mode --------------------
     p_fam = subparsers.add_parser(
@@ -193,9 +193,7 @@ Examples:
     # ------------ Options for 'familysubface' mode --------------------
     p_fam = subparsers.add_parser(
         "familysubface",
-        help="""Overwrite the family information on a subface. ***NOTE*** It is highly recommended that an output file
-                is specified as this method will overwrite existing boundary conditions on a face, and it is
-                up to the user to supply subfaces which sufficiently replace it.""",
+        help="""Overwrite the family information on a subface.""",
     )
     p_fam.add_argument("gridFile", help="Name of inputCGNS file")
     p_fam.add_argument(
@@ -204,7 +202,14 @@ Examples:
                 Format is 1st line: 1-based blockID, 2nd line: {ilow, ihigh, etc}, subsequent lines,
                 one per line: p_extractnge (as 6 ints seperated by commas, not spaces), newFamilyName""",
     )
-    p_fam.add_argument("outFile", nargs="?", default=None, help="Optional output file")
+    p_fam.add_argument(
+        "outFile",
+        nargs="?",
+        default=None,
+        help="""Optional output file. ***NOTE*** It is highly recommended that an output file
+                is specified as this method will overwrite existing boundary conditions on a face, and it is
+                up to the user to supply subfaces which sufficiently replace it.""",
+    )
 
     # ------------ Options for 'familycopy' mode --------------------
     p_fam = subparsers.add_parser("familycopy", help="Copy family information from two otherwise identical grids")

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -175,20 +175,17 @@ def get_parser():
     p_fam.add_argument("gridFile", help="Name of input CGNS file")
     p_fam.add_argument(
         "familyFile",
-        help="File containing additional family information. \
-    The file must consist of one or more lines contaning the following data: \n\
-    <blockID> <faceID> <family> \n\
-    \n\
-    where: \n\
-    blockID - is the block index *IN 1 BASED NUMBERING* \n\
-    faceID  - one of iLow, iHigh jLow, jHigh, kLow, or kHigh \n\
-    family  - the family name. \n\
-    \n\
-    Examples: \n\
-    \n\
-    7 kLow wing \n\
-    4 jHigh sym \n\
-    ",
+        help="""File containing additional family information. The file must consist of one or more lines contaning the following data:
+<blockID> <faceID> <family>
+where:
+    blockID - is the block index *IN 1 BASED NUMBERING*
+    faceID  - one of iLow, iHigh jLow, jHigh, kLow, or kHigh
+    family  - the family name.
+
+Examples:
+    7 kLow wing
+    4 jHigh sym
+""",
     )
 
     p_fam.add_argument("outFile", nargs="?", default=None, help="Optional output file")
@@ -204,8 +201,8 @@ def get_parser():
     p_fam.add_argument(
         "familyFile",
         help="""file containing data for the new families and face division.
-        Format is 1st line: 1-based blockID, 2nd line: {ilow, ihigh, etc},
-        subsequent lines, one per line: ptRange (as 6 ints seperated by commas, not spaces), newFamilyName""",
+                Format is 1st line: 1-based blockID, 2nd line: {ilow, ihigh, etc}, subsequent lines,
+                one per line: p_extractnge (as 6 ints seperated by commas, not spaces), newFamilyName""",
     )
     p_fam.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
@@ -227,39 +224,39 @@ def get_parser():
     p_sub.add_argument("gridFile", help="Name of input CGNS file")
     p_sub.add_argument(
         "bcFile",
-        help="File containing additional bc info. \
-    The file must consist of one or more lines contaning the following data: \n\
-    <blockID> <faceID> <BCType> <family> [dataset] \n\
-    \n\
-    where: \n\
-    blockID - is the block index *IN 1 BASED NUMBERING* \n\
-    faceID  - one of iLow, iHigh jLow, jHigh, kLow or kHigh \n\
-    BCType  - one of the supported CGNS boundary conditions. See below for supported types\n\
-    family  - the family name. \n\
-    \n\
-    Supported BC types are : bcfarfield, bcsymmetryplane bcwall, bcwallinviscid, bcwallviscous \n\
-    bcwallviscousheatflux, bcwallviscousisothermal, bcoutflow, bcoutflowsubsonic \n\
-    bcinflow, bcinflowsubsonic, bcinflowsupersonic \n\
-    \n\
-    Optionally, additional datasets may be specified. These \n\
-    can be used to set additional boundary condition data. \n\
-    The format of the dataset line is as follows: \n\
-    <BCSetName> <BCSetType> <DirNeuArr> <DataArrName1> <dataArr1>, ..., <DataArrNameN> <dataArrN> \n\
-    \n\
-    where: \n\
-    BCSetName     - bc dataset name \n\
-    BCSetType     - bc dataset type. This is in most cases the same type as the BCType specified \n\
-    DirNeuArr     - can have one of two options: Dirichlet or Neumann \n\
-    DataArrNameN  - name of first property specified. This can be a range of things. Refer to ICEM or ADflow for supported BC properties \n\
-    dataArrN      - the actual data for the property \n\
-    \n\
-    Note that only scalar values are supported at the moment for dataArrN.\n\
-    \n\
-    Examples: \n\
-    \n\
-    7 kLow bcwallviscous wing \n\
-    4 jHigh bcsymmetryplane sym\n\
-    5 khigh bcoutflowsubsonic turb_inlet BCDataSet_1 BCInFlowSubsonic Dirichlet PressureStagnation 1234.0 TemperatureStagnation 4556.0 \n",
+        help="""File containing additional bc info. The file must consist of one or more lines contaning the following data:
+<blockID> <faceID> <BCType> <family> [dataset]
+
+where:
+    blockID - is the block index *IN 1 BASED NUMBERING*
+    faceID  - one of iLow, iHigh jLow, jHigh, kLow or kHigh
+    BCType  - one of the supported CGNS boundary conditions. See below for supported types
+    family  - the family name.
+
+Supported BC types are : bcfarfield, bcsymmetryplane bcwall, bcwallinviscid, bcwallviscous
+bcwallviscousheatflux, bcwallviscousisothermal, bcoutflow, bcoutflowsubsonic
+bcinflow, bcinflowsubsonic, bcinflowsupersonic
+
+Optionally, additional datasets may be specified. These
+can be used to set additional boundary condition data.
+The format of the dataset line is as follows:
+<BCSetName> <BCSetType> <DirNeuArr> <DataArrName1> <dataArr1>, ..., <DataArrNameN> <dataArrN>
+
+where:
+    BCSetName     - bc dataset name
+    BCSetType     - bc dataset type. This is in most cases the same type as the BCType specified
+    DirNeuArr     - can have one of two options: Dirichlet or Neumann
+    DataArrNameN  - name of first property specified. This can be a range of things. Refer to ICEM or ADflow for supported BC properties
+    dataArrN      - the actual data for the property
+
+Note that only scalar values are supported at the moment for dataArrN.
+
+Examples:
+
+    7 kLow bcwallviscous wing
+    4 jHigh bcsymmetryplane sym
+    5 khigh bcoutflowsubsonic turb_inlet BCDataSet_1 BCInFlowSubsonic Dirichlet PressureStagnation 1234.0 TemperatureStagnation 4556.0
+""",
     )
     p_sub.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
@@ -318,12 +315,11 @@ def get_parser():
         "intDigits",
         type=int,
         default=5,
-        help="Number of digits used for the integers. \n\
-    When CGNSlib generates a CGNS file \n\
-    (when converting from a plot3d file, for instance), it does not add extra digits to the integers \n\
-    when naming zones. This becomes a problem when you have more than 10 zones because the ordering will be: \n\
-    Zone1, Zone11, Zone12, ..., Zone19, Zone2, Zone21, ...\n\
-    This method will add extra digits to the zone names to give the correct ordering.",
+        help="""Number of digits used for the integers. When CGNSlib generates a CGNS file
+                (when converting from a plot3d file, for instance), it does not add extra digits to the integers
+                when naming zones. This becomes a problem when you have more than 10 zones because the ordering will be:
+                Zone1, Zone11, Zone12, ..., Zone19, Zone2, Zone21, ...
+                This method will add extra digits to the zone names to give the correct ordering.""",
     )
     p_reorder.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
@@ -426,49 +422,51 @@ def get_parser():
     p_cart.add_argument("gridFile", help="Name of input CGNS file")
     p_cart.add_argument(
         "cartFile",
-        help="File containing background mesh info. The file must consist of \n\
-    4 lines contaning the following data: \n\
-    <extensionXneg> <extensionYneg> <extensionZneg> \n\
-    <extensionXpos> <extensionYpos> <extensionZpos> \n\
-    <numNodesX> <numNodesY> <numNodesZ> \n\
-    <weightGRX> <weightGRY> <weightGRZ> \n\
-    \n\
-    where: \n\
-    extension is the distance of the cartesian box\n\
-    face to the corresponding bounding box face divided by the\n\
-    bounding box length. We need 2 values of extension per \n\
-    direction as we have two parallel faces for each one of them.\n\
-    numNodes is the number of nodes that should be used along the \n\
-    edges of the cartesian mesh. If you want one symmetry plane\n\
-    in the z direction, for instance, you need to set one of the\n\
-    extensionZ values to 0. If you want two symmetry planes in\n\
-    the z direction, (e.g. to run a 2D case) you need to set both\n\
-    extensionZ values to 0.\n\
-    weightGR are values between 0.0 and 1.0 used to balance edge\n\
-    growth ratio and cell volume resolution mismatch during the\n\
-    optimization. If weightGR = 0, the optimizer will not care\n\
-    about the growth ratios at the farfield and will just try\n\
-    to match the bounding box resolution. If weightGR = 1, the\n\
-    optimizer will not care about the bounding box resolution\n\
-    and will just try to get an uniform growth ratio. This\n\
-    results in an uniform mesh.\n\n\
-    example:\n\
-    10 10 0\n\
-    10 10 10\n\
-    65 65 65\n\
-    0.1 0.1 0.1\n",
+        help="""File containing background mesh info. The file must consist of
+4 lines contaning the following data:
+
+<extensionXneg> <extensionYneg> <extensionZneg>
+<extensionXpos> <extensionYpos> <extensionZpos>
+<numNodesX> <numNodesY> <numNodesZ>
+<weightGRX> <weightGRY> <weightGRZ>
+
+where:
+    extension is the distance of the cartesian box
+    face to the corresponding bounding box face divided by the
+    bounding box length. We need 2 values of extension per
+    direction as we have two parallel faces for each one of them.
+
+    numNodes is the number of nodes that should be used along the
+    edges of the cartesian mesh. If you want one symmetry plane
+    in the z direction, for instance, you need to set one of the
+    extensionZ values to 0. If you want two symmetry planes in
+    the z direction, (e.g. to run a 2D case) you need to set both
+    extensionZ values to 0.
+
+    weightGR are values between 0.0 and 1.0 used to balance edge
+    growth ratio and cell volume resolution mismatch during the
+    optimization. If weightGR = 0, the optimizer will not care
+    about the growth ratios at the farfield and will just try
+    to match the bounding box resolution. If weightGR = 1, the
+    optimizer will not care about the bounding box resolution
+    and will just try to get an uniform growth ratio. This
+    results in an uniform mesh.
+
+example:
+    10 10 0
+    10 10 10
+    65 65 65
+    0.1 0.1 0.1
+""",
     )
     p_cart.add_argument(
         "outFile",
-        help="Name of output CGNS file \n\
-    The output file contains only one cartesian block. The input \n\
-    mesh is not included and BCs are applied.\n",
+        help="""Name of output CGNS file. The output file contains only one cartesian block.
+The input mesh is not included and BCs are applied.""",
     )
 
     # ------------ Options for 'simpleCart' mode --------------------
-    p_sub = subparsers.add_parser(
-        "simpleCart", help="Generates a background cartesian mesh", formatter_class=argparse.RawTextHelpFormatter
-    )
+    p_sub = subparsers.add_parser("simpleCart", help="Generates a background cartesian mesh")
     p_sub.add_argument("gridFile", help="Name of input CGNS file")
     p_sub.add_argument("dh", help="Uniform spacing size", type=float)
     p_sub.add_argument("hExtra", help="Extension in each dimension", type=float)
@@ -478,9 +476,7 @@ def get_parser():
     p_sub.add_argument("outFile", help="Name of output CGNS file")
 
     # ------------ Options for 'explicitCart' mode --------------------
-    p_sub = subparsers.add_parser(
-        "explicitCart", help="Generates a background cartesian mesh", formatter_class=argparse.RawTextHelpFormatter
-    )
+    p_sub = subparsers.add_parser("explicitCart", help="Generates a background cartesian mesh")
     p_sub.add_argument("xmin", type=float, help="min x coordinate")
     p_sub.add_argument("ymin", type=float, help="min y coordinate")
     p_sub.add_argument("zmin", type=float, help="min z coordinate")
@@ -495,11 +491,7 @@ def get_parser():
     p_sub.add_argument("outFile", help="Name of output CGNS file")
 
     # ------------ Options for 'simpleOCart' mode --------------------
-    p_sub = subparsers.add_parser(
-        "simpleOCart",
-        help="Generates a background cartesian mesh surrounding by an OMesh",
-        formatter_class=argparse.RawTextHelpFormatter,
-    )
+    p_sub = subparsers.add_parser("simpleOCart", help="Generates a background cartesian mesh surrounding by an OMesh")
     p_sub.add_argument("gridFile", help="Name of input CGNS file")
     p_sub.add_argument("dh", help="Uniform cartesian spacing size", type=float)
     p_sub.add_argument("hExtra", help='Extension in "O" dimension', type=float)
@@ -573,7 +565,7 @@ def get_parser():
     p_fbc.add_argument("gridFile", help="Name of input CGNS file")
     p_fbc.add_argument(
         "bocoType",
-        help="""Boundary condition type. Supported types are: \n
+        help="""Boundary condition type. Supported types are:
                 bcfarfield, bcsymmetryplane, bcwall, bcwallinviscid, bcwallviscous, bcwallviscousheatflux,
                 bcwallviscousisothermal, bcoutflow, bcoutflowsubsonic, bcoutflowsupersonic, bcinflow, bcinflowsubsonic,
                 bcinflowsupersonic and bcoverset""",

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -37,6 +37,9 @@ from cgnsutilities.cgnsutilities import (
     libcgns_utils,
 )
 
+# set width of printing for line wrap
+os.environ["COLUMNS"] = "120"
+
 
 def get_parser():
     # List out all of the possible options here.
@@ -53,14 +56,12 @@ def get_parser():
     # ------------- Options for 'flip' mode --------------------
     p_flip = subparsers.add_parser(
         "flip",
-        help="Flip a grid about a plane defined \
-    by an axis",
+        help="Flip a grid about a plane defined by an axis",
     )
     p_flip.add_argument("gridFile", help="Name of input CGNS file")
     p_flip.add_argument(
         "axis",
-        help="Flip the mesh about plane defined by \
-    axis: 'x', 'y', 'z'",
+        help="Flip the mesh about plane defined by axis: 'x', 'y', 'z'",
     )
     p_flip.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
@@ -75,8 +76,7 @@ def get_parser():
     p_refine.add_argument(
         "--axes",
         nargs="+",
-        help="Refine mesh only along specified axis or axes ( default is all three axes): 'i', 'j', 'k'\
-                                                    ",
+        help="Refine mesh only along specified axis or axes ( default is all three axes): 'i', 'j', 'k'",
         default=["i", "j", "k"],
     )
 
@@ -102,8 +102,7 @@ def get_parser():
     # ------------- Options for 'mirror' mode --------------------
     p_mirror = subparsers.add_parser(
         "mirror",
-        help="Mirror a grid about a plane defined \
-                                    by an axis. This doubles the grid size",
+        help="Mirror a grid about a plane defined by an axis. This doubles the grid size",
     )
     p_mirror.add_argument("gridFile", help="Name of input CGNS file")
     p_mirror.add_argument("axis", help="Mirror about plane defined by axis: 'x', 'y', 'z'")
@@ -113,9 +112,7 @@ def get_parser():
     # ------------- Options for 'split' mode --------------------
     p_split = subparsers.add_parser(
         "split",
-        help="Face-match a grid. If the grid is \
-                                    already faced matched, this witll have no \
-                                    effect",
+        help="Face-match a grid. If the grid is already faced matched, this witll have no effect",
     )
     p_split.add_argument("gridFile", help="Name of input CGNS file")
     p_split.add_argument("outFile", nargs="?", default=None, help="Optional output file")
@@ -123,16 +120,15 @@ def get_parser():
         "--splitFile",
         nargs="?",
         default=None,
-        help="Add additional splits specified in split file. Each\
-                        line must contain a block index (1 based), idim (1, 2, or 3),\
-                        and a 1-based index of the block to split at",
+        help="""Add additional splits specified in split file. Each
+                line must contain a block index (1 based), idim (1, 2, or 3),
+                and a 1-based index of the block to split at""",
     )
 
     # ------------- Options for 'merge' mode --------------------
     p_merge = subparsers.add_parser(
         "merge",
-        help="Automatically merge as many blocks as possible.\
-                                    Boundary conditions and family information is kept.",
+        help="Automatically merge as many blocks as possible. Boundary conditions and family information is kept.",
     )
     p_merge.add_argument("gridFile", help="Name of input CGNS file")
     p_merge.add_argument("outFile", nargs="?", default=None, help="Optional output file")
@@ -140,8 +136,7 @@ def get_parser():
     # ------------- Options for 'connect' mode --------------------
     p_connect = subparsers.add_parser(
         "connect",
-        help="Determine the block-to-block connectivity information \
-        for a point-matched grid",
+        help="Determine the block-to-block connectivity information for a point-matched grid",
     )
     p_connect.add_argument("gridFile", help="Name of input CGNS file")
     p_connect.add_argument("tol", nargs="?", default=1e-12, help="Tolerance for node merge")
@@ -162,8 +157,7 @@ def get_parser():
     # ------------- Options for 'autobc' mode --------------------
     p_bc = subparsers.add_parser(
         "autobc",
-        help="Try to determine boundary conditions for blocks. Only \
-        suitable for external flow applications.",
+        help="Try to determine boundary conditions for blocks. Only suitable for external flow applications.",
     )
     p_bc.add_argument("gridFile", help="Name of input CGNS file")
     p_bc.add_argument("sym", help="Normal for possible symmetry plane.", choices=["x", "y", "z"])
@@ -201,18 +195,16 @@ def get_parser():
     # ------------ Options for 'familysubface' mode --------------------
     p_fam = subparsers.add_parser(
         "familysubface",
-        help="Overwrite the family information on a subface \n \
-        ***NOTE*** It is highly recommended that an output file is specified \
-        as this method will overwrite existing boundary conditions on a face, and \
-        it is up to the user to supply subfaces which sufficiently replace it.",
+        help="""Overwrite the family information on a subface. ***NOTE*** It is highly recommended that an output file
+                is specified as this method will overwrite existing boundary conditions on a face, and it is
+                up to the user to supply subfaces which sufficiently replace it.""",
     )
     p_fam.add_argument("gridFile", help="Name of inputCGNS file")
     p_fam.add_argument(
         "familyFile",
-        help="file containing data for the new \
-    families and face division. Format is 1st line: 1-based blockID, 2nd line: \
-    {ilow, ihigh, etc}, subsequent lines, one per line: ptRange (as 6 \
-    ints seperated by commas-not spaces), newFamilyName",
+        help="""file containing data for the new families and face division.
+        Format is 1st line: 1-based blockID, 2nd line: {ilow, ihigh, etc},
+        subsequent lines, one per line: ptRange (as 6 ints seperated by commas, not spaces), newFamilyName""",
     )
     p_fam.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
@@ -277,15 +269,13 @@ def get_parser():
     p_bunch.add_argument("outFile", nargs="?", default=None, help="Optional output file")
     p_bunch.add_argument(
         "--extraCells",
-        help="Number of additional cells to \
-    use in re-bunching. *SHOULD BE A MG NUMBER*.",
+        help="Number of additional cells to use in re-bunching. *SHOULD BE A MG NUMBER*.",
         type=int,
         default=0,
     )
     p_bunch.add_argument(
         "--nodes",
-        help="Only rebunch the first 'nodes' in the \
-    offwall direction",
+        help="Only rebunch the first 'nodes' in the offwall direction",
         type=int,
         default=1,
     )
@@ -298,8 +288,8 @@ def get_parser():
     # ------------ Options for 'plot3dtocgns' mode --------------------
     p3dtoc = subparsers.add_parser(
         "plot3d2cgns",
-        help="Convert a multiblock, unformatted fortran, big-endian, multiblock plot3d file to a plain \
-        cgns file. This specific format is widely used at NASA and Boeing.",
+        help="""Convert a multiblock, unformatted fortran, big-endian, multiblock plot3d file to a plain
+                cgns file. This specific format is widely used at NASA and Boeing.""",
     )
     p3dtoc.add_argument("plot3dFile", help="Name of input plot3d file")
     p3dtoc.add_argument("gridFile", help="Name of output CGNS file")
@@ -311,8 +301,7 @@ def get_parser():
         "seed",
         type=int,
         default=0,
-        help="Seed for random generator. \
-    Specifying a seed will make process deterministic.",
+        help="Seed for random generator. Specifying a seed will make process deterministic.",
     )
     p_ran.add_argument("--keepRHS", help="Keep right hand coordinate system", action="store_true", default=False)
     p_ran.add_argument("outFile", nargs="?", default=None, help="Optional output file")
@@ -320,8 +309,8 @@ def get_parser():
     # ------------ Options for 'reorder' mode --------------------
     p_reorder = subparsers.add_parser(
         "reorder",
-        help="Sort blocks in an alpha-numerical order. It can also add extra digits \
-        to the integers at the end of the block names to facilitate ordering.",
+        help="""Sort blocks in an alpha-numerical order. It can also add extra digits
+                to the integers at the end of the block names to facilitate ordering.""",
     )
     p_reorder.add_argument("gridFile", help="Name of input CGNS file")
     p_reorder.add_argument(
@@ -419,16 +408,15 @@ def get_parser():
         "outFile",
         nargs="?",
         default=None,
-        help="Optional reference to name output files. \n\
-    An integer will be added to the end. \n\
-    if none is given, the input filename will be used as reference.",
+        help="""Optional reference to name output files. An integer will be added to the end.
+                if none is given, the input filename will be used as reference.""",
     )
 
     # ------------ Options for 'explodeByZoneName' mode  --------------------
     p_expkmin = subparsers.add_parser(
         "explodeByZoneName",
-        help="Take one multiblock cgns file and explode it into multiple multiblock \n\
-        cgns files based on the zone name from the blocks.",
+        help="""Take one multiblock cgns file and explode it into multiple multiblock
+                cgns files based on the zone name from the blocks.""",
     )
     p_expkmin.add_argument("gridFile", type=str, help="Name of input multiblock CGNS file")
 
@@ -581,15 +569,15 @@ def get_parser():
     # ------------ Options for 'fillOpenBCs' mode
     p_fbc = subparsers.add_parser(
         "fillOpenBCs",
-        help="Adds a given BC to the faces that are not face-matched and \
-        also that do not have any previously-assigned BCs.",
+        help="Adds a given BC to the faces that are not face-matched and also that do not have any previously-assigned BCs.",
     )
     p_fbc.add_argument("gridFile", help="Name of input CGNS file")
     p_fbc.add_argument(
         "bocoType",
-        help="Boundary condition type. Supported types are: \
-    bcfarfield, bcsymmetryplane, bcwall, bcwallinviscid, bcwallviscous, bcwallviscousheatflux, \
-    bcwallviscousisothermal, bcoutflow, bcoutflowsubsonic, bcoutflowsupersonic, bcinflow, bcinflowsubsonic, bcinflowsupersonic and bcoverset",
+        help="""Boundary condition type. Supported types are: \n
+                bcfarfield, bcsymmetryplane, bcwall, bcwallinviscid, bcwallviscous, bcwallviscousheatflux,
+                bcwallviscousisothermal, bcoutflow, bcoutflowsubsonic, bcoutflowsupersonic, bcinflow, bcinflowsubsonic,
+                bcinflowsupersonic and bcoverset""",
     )
     p_fbc.add_argument("famName", help="Family name for the new BCs.")
     p_fbc.add_argument("outFile", nargs="?", default=None, help="Optional output file")
@@ -597,8 +585,7 @@ def get_parser():
     # ------------ Options for 'extractConv' mode  --------------------
     p_conv = subparsers.add_parser(
         "extractConv",
-        help="Reads the convergence history node of a CGNS file and saves the \
-        data in a pickle or tecplot file.",
+        help="Reads the convergence history node of a CGNS file and saves the data in a pickle or tecplot file.",
     )
     p_conv.add_argument("gridFile", type=str, help="Name of input CGNS file.")
     p_conv.add_argument("outType", choices=["pickle", "tecplot"], help="The type of convergence data output file.")
@@ -606,8 +593,7 @@ def get_parser():
         "outFile",
         nargs="?",
         default=None,
-        help="The convergence data will be saved to this filename. \
-    If none is given, the grid filename will be used as reference.",
+        help="The convergence data will be saved to this filename. If none is given, the grid filename will be used as reference.",
     )
 
     # ------------ Options for 'include' mode
@@ -617,16 +603,15 @@ def get_parser():
     p_inc.add_argument("gridFile", help="Name of input CGNS file")
     p_inc.add_argument(
         "rangeSpec",
-        help="Range to extract. Comma separated list. \
-    Ranges can given like 6-8. Must be 1 based. Exampe: rangeSpec=4,5,9-16,19",
+        help="""Range to extract. Comma separated list. Ranges can given like 6-8. Must be 1 based.
+                Example: rangeSpec=4,5,9-16,19""",
     )
     p_inc.add_argument("outFile", help="Output file")
 
     # ------------ Options for 'section' mode
     p_sec = subparsers.add_parser(
         "section",
-        help="For cgns files with 1 domain ONLY, write a subsection of the\
-    zone. Boundary conditions/B2Bs are deleted.",
+        help="For cgns files with 1 domain ONLY, write a subsection of the zone. Boundary conditions/B2Bs are deleted.",
     )
     p_sec.add_argument("gridFile", help="Name of input CGNS file")
     p_sec.add_argument("iStart", type=int)
@@ -644,14 +629,13 @@ def get_parser():
     # ------------ Options for 'extrude' mode
     p_p2D = subparsers.add_parser(
         "extrude",
-        help="Takes a true 2D mesh (planar) and extrude it in one direction to make \
-        it a 3D mesh, one cell wide. This method assumes that BCs are already set in the CGNS file. \
-        BCs are retained and symmetry BCs are applied on planar surfaces.",
+        help="""Takes a true 2D mesh (planar) and extrude it in one direction to make
+                it a 3D mesh, one cell wide. This method assumes that BCs are already set in the CGNS file.
+                BCs are retained and symmetry BCs are applied on planar surfaces.""",
     )
     p_p2D.add_argument(
         "gridFile",
-        help="Name of input CGNS file. Note that the planar grid should \
-        not have symmetry BCs set on the plane.",
+        help="Name of input CGNS file. Note that the planar grid should not have symmetry BCs set on the plane.",
     )
     p_p2D.add_argument("direction", help="Direction which to extrude the grid", choices=["x", "y", "z"])
     p_p2D.add_argument("outFile", nargs="?", default=None, help="Optional output CGNS file")
@@ -659,25 +643,23 @@ def get_parser():
     # ------------ Options for 'revolve' mode
     p_p2R = subparsers.add_parser(
         "revolve",
-        help="Takes a true 2D mesh (planar) and reloves it about specified axis to make \
-        a 3D axisymmetric mesh, one cell wide. This method assumes that BCs are already set in the CGNS file. \
-        BCs are retained and symmetry BCs are applied on planar surfaces. Output should be a wedge shape.",
+        help="""Takes a true 2D mesh (planar) and reloves it about specified axis to make
+                a 3D axisymmetric mesh, one cell wide. This method assumes that BCs are already set in the CGNS file.
+                BCs are retained and symmetry BCs are applied on planar surfaces. Output should be a wedge shape.""",
     )
     p_p2R.add_argument(
         "gridFile",
-        help="Name of input CGNS file. Note that the planar grid should \
-        not have symmetry BCs set on the plane.",
+        help="Name of input CGNS file. Note that the planar grid should not have symmetry BCs set on the plane.",
     )
     p_p2R.add_argument(
         "normalDirection",
-        help="This is the direction in which the plane normal points in. \
-                        Example: If supplied data is in xz plane, the normal points in y",
+        help="""This is the direction in which the plane normal points in.
+                Example: If supplied data is in xz plane, the normal points in y""",
         choices=["x", "y", "z"],
     )
     p_p2R.add_argument(
         "axis",
-        help="Axis which to rotate about \
-                        Example: If supplied data is in xz plane, you would give either x or z",
+        help="Axis which to rotate about Example: If supplied data is in xz plane, you would give either x or z",
         choices=["x", "y", "z"],
     )
     p_p2R.add_argument(

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -71,13 +71,14 @@ def get_parser():
     p_coarsen.add_argument("gridFile", help="Name of input CGNS file")
     p_coarsen.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
+    # ------------- Options for 'refine' mode --------------------
     p_refine = subparsers.add_parser("refine", help="Refine a grid uniformly")
     p_refine.add_argument("gridFile", help="Name of input CGNS file")
     p_refine.add_argument("outFile", nargs="?", default=None, help="Optional output file")
     p_refine.add_argument(
         "--axes",
         nargs="+",
-        help="Refine mesh only along specified axis or axes ( default is all three axes): 'i', 'j', 'k'",
+        help="Refine mesh only along specified axis or axes (default: %(default)s)",
         default=["i", "j", "k"],
     )
 
@@ -343,8 +344,7 @@ Examples:
     p_symnobc.add_argument("sym", help="Normal for possible symmetry plane.", choices=["x", "y", "z"])
     p_symnobc.add_argument(
         "--tol",
-        help="Distance tolerance to bring nodes to symmetry plane.\n\
-                                        Default is 1.0e-5.",
+        help="Distance tolerance to bring nodes to symmetry plane (default: %(default)s)",
         type=float,
         default=1.0e-5,
     )


### PR DESCRIPTION
## Purpose
This is an attempt at cleaning up the help string:
- correctly use the raw formatter. No newlines are needed if triple quotes are used
- use triple quotes to auto line wrap without manual insertion of `\n`
- set the display width to 120 characters via overloading of environment variables. Lines longer than this are wrapped (unless raw formatting is used)
- replaced hard-coded default values in help string with placeholder

There are plenty of things that we can improve:
- Rename some "modes" to use camelCase for readability (this will break backwards compatibility probably unless we allow any case and uniformly cast to lower)
- print more defaults for other options. We will have to come up with a smart way to do this without printing a lot of `(default: None)`
- Fix some defaults. For some stuff (e.g. `outFile` for `timecombine` the default is `None`, but later on we just replace it with another default. We should probably just set the default in the argparser directly)
- Fix display of help string. Right now, the help string for each mode is shown with `cgns_utils -h` but not when specific modes are queried. Ideally, they should be shown in both places and the `description=` option may do this.

There is also an open question of whether we want a docs page for this. Some of the help text spans too many lines, so maybe they should go into a docs page instead? For example, I don't think it's necessary to describe the structure of some input files via the help string.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Existing tests pass. There are no functionality changes and I did manually check a lot of the help text.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
