### PR TITLE
Pass options to simpleOCart

### DIFF
--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -584,7 +584,7 @@ class Grid(object):
         # Call the generic routine
         return simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile)
 
-    def simpleOCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile, comm=None):
+    def simpleOCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile, comm=None, userOptions=None):
         """Generates a cartesian mesh around the provided grid, surrounded by
         an O-Mesh"""
 
@@ -611,7 +611,7 @@ class Grid(object):
         if "z" not in sym and "zmin" not in sym:
             patches.append(X[:, :, 0, :][::-1, :, :])
 
-        # Set up the generic input for pyHyp:
+        # Set up the generic input for pyHyp
         hypOptions = {
             "patches": patches,
             "unattachedEdgesAreSymmetry": True,
@@ -623,6 +623,10 @@ class Grid(object):
             "marchDist": hExtra,
             "cmax": 3.0,
         }
+
+        # Use user-defined options if provided
+        if userOptions is not None:
+            hypOptions.update(userOptions)
 
         # Run pyHyp
         from pyhyp import pyHyp

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -2451,7 +2451,7 @@ def getS(N, s0, S):
 
     fa = S - f(a)
 
-    for i in range(100):
+    for _i in range(100):
         c = 0.5 * (a + b)
         ff = S - f(c)
         if abs(ff) < 1e-6:
@@ -2727,7 +2727,7 @@ def readGrid(fileName):
                     ) = libcgns_utils.utils.getbcdatasetinfo(inFile, iBlock, iBoco, iBocoDataSet)
                     bcDSet = BocoDataSet(bocoDatasetName, bocoType)
 
-                    def getBocoDataSetArray(flagDirNeu):
+                    def getBocoDataSetArray(flagDirNeu, iDir):
                         # Get data information
                         (
                             dataArrayName,
@@ -2756,7 +2756,7 @@ def readGrid(fileName):
                         for iDir in range(1, nDirichletArrays + 1):
 
                             # Get the data set
-                            bcDSetArr = getBocoDataSetArray(BCDATATYPE["Dirichlet"])
+                            bcDSetArr = getBocoDataSetArray(BCDATATYPE["Dirichlet"], iDir)
 
                             # Append a BocoDataSetArray to the datasets
                             bcDSet.addDirichletDataSet(bcDSetArr)
@@ -2766,10 +2766,10 @@ def readGrid(fileName):
 
                     if nNeumannArrays > 0:
                         # Loop over Neumann data sets
-                        for nDir in range(1, nNeumannArrays + 1):
+                        for iDir in range(1, nNeumannArrays + 1):
 
                             # Get the data set
-                            bcDSetArr = getBocoDataSetArray(BCDATATYPE["Neumann"])
+                            bcDSetArr = getBocoDataSetArray(BCDATATYPE["Neumann"], iDir)
 
                             # Append a BocoDataSetArray to the datasets
                             bcDSet.addNeumannDataSet(bcDSetArr)
@@ -3172,7 +3172,7 @@ def combineGrids(grids, useOldNames=False):
     # Create a dictionary to contain grid objects with their names
     # as the corresponding keys
     gridDict = {}
-    for j, grid in enumerate(grids):
+    for _j, grid in enumerate(grids):
 
         # Get the name of the grid
         gridDict[grid.name] = grid

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -568,7 +568,7 @@ class Grid(object):
             blk.double2D()
 
     def simpleCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile):
-        """Generates a cartesian mesh around the provided grid"""
+        """Generates a Cartesian mesh around the provided grid"""
 
         # Get the bounds of each grid.
         xMin = 1e20 * numpy.ones(3)
@@ -584,9 +584,11 @@ class Grid(object):
         # Call the generic routine
         return simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile)
 
-    def simpleOCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile, comm=None, userHypOptions=None):
-        """Generates a cartesian mesh around the provided grid, surrounded by
-        an O-Mesh"""
+    def simpleOCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile, userOptions=None):
+        """Generates a Cartesian mesh around the provided grid, surrounded by an O-mesh.
+        This function requires pyHyp to be installed. If this function is run with MPI,
+        pyHyp will be run in parallel.
+        """
 
         # First run simpleCart with no extension:
         X, dx = self.simpleCart(dh, 0.0, 0, sym, mgcycle, outFile=None)
@@ -625,8 +627,8 @@ class Grid(object):
         }
 
         # Use user-defined options if provided
-        if userHypOptions is not None:
-            hypOptions.update(userHypOptions)
+        if userOptions is not None:
+            hypOptions.update(userOptions)
 
         # Run pyHyp
         from pyhyp import pyHyp
@@ -666,13 +668,13 @@ class Grid(object):
             os.remove(fName)
 
     def cartesian(self, cartFile, outFile):
-        """Generates a cartesian mesh around the provided grid"""
+        """Generates a Cartesian mesh around the provided grid"""
 
         # PARAMETERS
         inLayer = 2  # How many layers of the overset interpolation
         # faces will be used for volume computation
 
-        print("Running cartesian grid generator")
+        print("Running Cartesian grid generator")
 
         # Preallocate arrays
         extensions = numpy.zeros((2, 3), order="F")
@@ -2529,7 +2531,7 @@ def inRange(ptRange, chkRange):
 
 def simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile):
     """
-    Generates a cartesian mesh
+    Generates a Cartesian mesh
 
     Parameters
     ----------

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -584,7 +584,7 @@ class Grid(object):
         # Call the generic routine
         return simpleCart(xMin, xMax, dh, hExtra, nExtra, sym, mgcycle, outFile)
 
-    def simpleOCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile, comm=None, userOptions=None):
+    def simpleOCart(self, dh, hExtra, nExtra, sym, mgcycle, outFile, comm=None, userHypOptions=None):
         """Generates a cartesian mesh around the provided grid, surrounded by
         an O-Mesh"""
 
@@ -625,8 +625,8 @@ class Grid(object):
         }
 
         # Use user-defined options if provided
-        if userOptions is not None:
-            hypOptions.update(userOptions)
+        if userHypOptions is not None:
+            hypOptions.update(userHypOptions)
 
         # Run pyHyp
         from pyhyp import pyHyp
@@ -3172,7 +3172,7 @@ def combineGrids(grids, useOldNames=False):
     # Create a dictionary to contain grid objects with their names
     # as the corresponding keys
     gridDict = {}
-    for _j, grid in enumerate(grids):
+    for grid in grids:
 
         # Get the name of the grid
         gridDict[grid.name] = grid


### PR DESCRIPTION
## Purpose
I added the ability to pass in a pyHyp options dictionary to simpleOCart. This can be useful for fine-tuning the extrusion. The default behavior is unchanged.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
