### PR TITLE
Bounding box function and mirrorGrid changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 src/libcgns_utils-f2pywrappers2.f90
 src/libcgns_utilsmodule.c
 examples/717_wl_L2_overwriteBCs.cgns
+examples/717_wl_L2_overwriteBCs_array.cgns
 examples/717_wl_L2_overwriteFamilies.cgns
+examples/717_wl_L2_overwriteBCFamilyWithBC.cgns
 
 config.mk

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -103,6 +103,7 @@ def get_parser():
     p_mirror.add_argument("axis", help="Mirror about plane defined by axis: 'x', 'y', 'z'")
     p_mirror.add_argument("tol", nargs="?", default=1e-12, help="Tolerance for node merge")
     p_mirror.add_argument("useOldNames", nargs="?", default=False, help="Whether to use old block names")
+    p_mirror.add_argument("surface", nargs="?", default=False, help="Whether this is a surface or volume grid")
     p_mirror.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
     # ------------- Options for 'split' mode --------------------
@@ -838,7 +839,7 @@ def main():
         curGrid.scale(args.scale)
 
     elif args.mode == "mirror":
-        curGrid = mirrorGrid(curGrid, args.axis, args.tol, useOldNames=args.useOldNames)
+        curGrid = mirrorGrid(curGrid, args.axis, args.tol, useOldNames=args.useOldNames, surface=args.surface)
 
     elif args.mode == "coarsen":
         curGrid.coarsen()

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -860,7 +860,7 @@ class Grid(object):
                 Eq2 = a * (np.tan(b / N + c) - np.tan(c)) - Sp1
                 Eq3 = a * (np.tan(b + c) - np.tan(b * (1 - 1 / N) + c)) - Sp2
                 # Cost function
-                J = Eq1**2 + Eq2**2 + Eq3**2
+                J = Eq1 ** 2 + Eq2 ** 2 + Eq3 ** 2
                 # Return
                 return J
 
@@ -1436,7 +1436,7 @@ class Grid(object):
         """
 
         # Normalize the components of the rotation vector
-        normV = np.sqrt(vx**2 + vy**2 + vz**2)
+        normV = np.sqrt(vx ** 2 + vy ** 2 + vz ** 2)
         uu = vx / normV
         vv = vy / normV
         ww = vz / normV
@@ -2984,6 +2984,7 @@ def mirrorGrid(grid, axis, tol, useOldNames=True):
 
     return newGrid
 
+
 def mirrorGridSurface(grid, axis, useOldNames=True):
     """Method that takes a *surface* grid and mirrors about the axis. Boundary
     condition information is retained if possible"""
@@ -3014,6 +3015,7 @@ def mirrorGridSurface(grid, axis, useOldNames=True):
         newGrid.renameBlocks()
 
     return newGrid
+
 
 def divideGrid(grid):
     """Method that takes a grid and generates a new grid with 8 times

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -860,7 +860,7 @@ class Grid(object):
                 Eq2 = a * (np.tan(b / N + c) - np.tan(c)) - Sp1
                 Eq3 = a * (np.tan(b + c) - np.tan(b * (1 - 1 / N) + c)) - Sp2
                 # Cost function
-                J = Eq1 ** 2 + Eq2 ** 2 + Eq3 ** 2
+                J = Eq1**2 + Eq2**2 + Eq3**2
                 # Return
                 return J
 
@@ -1436,7 +1436,7 @@ class Grid(object):
         """
 
         # Normalize the components of the rotation vector
-        normV = np.sqrt(vx ** 2 + vy ** 2 + vz ** 2)
+        normV = np.sqrt(vx**2 + vy**2 + vz**2)
         uu = vx / normV
         vv = vy / normV
         ww = vz / normV

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -2973,7 +2973,7 @@ def mirrorGrid(grid, axis, tol, useOldNames=True):
         mirrorBlk.flip(axis)
         if useOldNames:
             # overwrite the name of the mirror block
-            mirrorBlk.name = blk.name.split(".")[0] + "_mirror." + blk.name.split(".")[1]
+            mirrorBlk.name = blk.name.split(".")[0] + "_mirror." + blk.name.split(".")[-1]
         newGrid.addBlock(mirrorBlk)
 
     # Now rename the blocks and redo-connectivity
@@ -3007,7 +3007,7 @@ def mirrorGridSurface(grid, axis, useOldNames=True):
         mirrorBlk.flip(axis)
         if useOldNames:
             # overwrite the name of the mirror block
-            mirrorBlk.name = blk.name.split(".")[0] + "_mirror." + blk.name.split(".")[1]
+            mirrorBlk.name = blk.name.split(".")[0] + "_mirror." + blk.name.split(".")[-1]
         newGrid.addBlock(mirrorBlk)
 
     # Now rename the blocks and redo-connectivity

--- a/tests/test_cgnsutilities.py
+++ b/tests/test_cgnsutilities.py
@@ -295,15 +295,15 @@ class TestReturnFuncs(unittest.TestCase):
         # Test mirroring function with useOldNames=True option
         newNameList = [
             "domain.00001",
+            "domain_mirror.00001",
+            "domain.00002",
             "domain_mirror.00002",
             "domain.00003",
+            "domain_mirror.00003",
+            "domain.00004",
             "domain_mirror.00004",
             "domain.00005",
-            "domain_mirror.00006",
-            "domain.00007",
-            "domain_mirror.00008",
-            "domain.00009",
-            "domain_mirror.00010",
+            "domain_mirror.00005",
         ]
         newMirrorGrid = mirrorGrid(self.grid1, "z", 1e-12, useOldNames=True)
         newNames = [blk.name for blk in newMirrorGrid.blocks]


### PR DESCRIPTION
This PR replicates the changes in https://github.com/mdolab/cgnsutilities/pull/58. The old PR was closed w/o merging because of conflicts I did not want to deal with. 

Here, I added the method to get the bounding boxes from grids, which can be then used to fine tune the cartesian grid coordinates in: https://github.com/mdolab/pyhyp/pull/65 I also made slight modifications to the mirror grid call because it was not working for what I needed to do. Finally, a new function to mirror surface grids (the default mirror only works on volume)

## Purpose

## Expected time until merged
few days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
