### PR TITLE
Allow GCC 10+ to compile

### DIFF
--- a/config/compilerCheck.sh
+++ b/config/compilerCheck.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Need one argument at least
+if [ -z $1 ]; then
+    echo "$0 needs to be called with the compiler name as an argument"; exit 1
+fi
+
+# Initialize variables
+FF90=$1
+FFLAGS=""
+
+
+# Allow argument mismatch for gfortran >= 10
+
+# NOTE: The primary reason for this is that the CGNS library does not provide explicit
+# Fortran interface at this time for some of the functions as mentioned
+# in the docs https://cgns.github.io/CGNS_docs_current/midlevel/general.html
+# and source https://github.com/CGNS/CGNS/blob/develop/src/cgns_f.F90
+# Once CGNS lib supports explicit interface this script should be removed
+# and any issues with the code addressed.
+
+fc=$("$FF90" --version 2>&1 | grep -i 'gnu')
+if [ ! -z "$fc" ]; then
+    # Get the GNU compiler version
+    version=$("$FF90" -v 2>&1 | grep 'gcc version' | cut -d' ' -f3)
+    if [ ! -z "$version" ]; then
+      # Get the major version
+      version_major=`echo $version | cut -f1 -d.`
+    fi
+
+    if [ $version_major -ge 10 ]; then
+        FFLAGS="-fallow-argument-mismatch"
+    fi
+fi
+
+# Print at end to add to the makefile
+echo "$FFLAGS"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,11 @@
 include ../config.mk
 
+# Check compiler and version and add flags if needed
+EXTRA_FFLAGS = $(shell bash ../config/compilerCheck.sh $(FC))
+
+# Append any flags
+FFLAGS += $(EXTRA_FFLAGS)
+
 PYTHON_OBJECTS = fortranobject.o \
 		 kd_tree.o \
 		 libcgns_utilsmodule.o \


### PR DESCRIPTION
## Purpose
This PR adds a script that checks the compiler version and injects the `-fallow-argument-mismatch` flag if it detects GCC version 10 and newer. This is due to a type mismatch error, e.g., 
```
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/INTEGER(4)).
```

For more detail and discussion on the issue, see https://github.com/mdolab/adflow/issues/243.

## Expected time until merged
0-3 days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Test compiling with GCC 10+ either locally or in a container.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
