### PR TITLE
Add option to print bc and block info to terminal

### DIFF
--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -18,6 +18,7 @@ import pickle
 import shutil
 import sys
 import tempfile
+import warnings
 
 import numpy as np
 
@@ -746,8 +747,12 @@ meshes for 2D cases (remember to set dh to the span length
     p_test.add_argument("outFile", help="Name of output file")
 
     # ------------- Options for 'blockSizes' mode --------------------
-    p_blockSizes = subparsers.add_parser("blockSizes", help="Print the sizes of each block in the mesh")
+    p_blockSizes = subparsers.add_parser("blockSizes", help="Print the sizes of each block in the mesh (deprecated)")
     p_blockSizes.add_argument("gridFile", help="Name of input CGNS file")
+
+    # ------------- Options for 'printBlockInfo' mode --------------------
+    p_printBlockInfo = subparsers.add_parser("printBlockInfo", help="Print information about each block in the mesh")
+    p_printBlockInfo.add_argument("gridFile", help="Name of input CGNS file")
 
     # return the parser
     return parser
@@ -757,6 +762,14 @@ def main():
     parser = get_parser()
     # Get the arguments we need!
     args = parser.parse_args()
+
+    # Check for deprecated modes
+    if args.mode == "blockSizes":
+        warnings.warn(
+            "The 'blockSizes' mode is deprecated. Please use 'info' or 'printBlockInfo' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     # -------------------------------------------
     #         Selection of the task
@@ -881,7 +894,7 @@ def main():
         curGrid.writePlot3d(args.plot3dFile)
         sys.exit(0)
 
-    if args.mode == "blockSizes":
+    if args.mode == "blockSizes" or args.mode == "printBlockInfo":
         curGrid.printBlockInfo()
         sys.exit(0)
 

--- a/cgnsutilities/cgns_utils.py
+++ b/cgnsutilities/cgns_utils.py
@@ -217,6 +217,10 @@ Examples:
     p_rem.add_argument("gridFile", help="Name of input CGNS file")
     p_rem.add_argument("outFile", nargs="?", default=None, help="Optional output file")
 
+    # ------------ Options for 'printBCInfo' mode --------------------
+    p_rem = subparsers.add_parser("printBCInfo", help="Print BC information to screen")
+    p_rem.add_argument("gridFile", help="Name of input CGNS file")
+
     # ------------ Options for 'overwriteBCFamilyWithBC' mode --------------------
     p_sub = subparsers.add_parser(
         "overwriteBCFamilyWithBC",
@@ -951,6 +955,10 @@ def main():
 
     elif args.mode == "removebc":
         curGrid.removeBCs()
+
+    elif args.mode == "printBCInfo":
+        curGrid.printBCInfo()
+        sys.exit(0)
 
     elif args.mode == "rebunch":
         curGrid.rebunch(args.spacing, args.extraCells, args.nodes)

--- a/cgnsutilities/cgnsutilities.py
+++ b/cgnsutilities/cgnsutilities.py
@@ -447,7 +447,6 @@ class Grid(object):
                 print(textwrap.indent(str(boco), "  "))
                 print("")
 
-
     def overwriteBCs(self, bcFile):
         """Overwrite BCs with information given in the file"""
 


### PR DESCRIPTION
## Purpose
This PR improves the block and BC information printed to the terminal. Two options are added 
- `printBlockInfo` - This option prints various basic information about each block. This option replaces the `blockSizes` options. Added a deprecation warning to `blockSizes` for now to keep this backwards compatible. 
- `printBCInfo` - prints details (see output below) for every BC associated to each block in the grid.

Both options are convenient when working with meshes, such as overset, with many families and types. This eliminates the need to inspect the information in other tools. Its also convenient to print python objects directly when working with them.

## Expected time until merged
No rush

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
